### PR TITLE
fix exception :: add null check

### DIFF
--- a/Core/Logger/LogMessage.php
+++ b/Core/Logger/LogMessage.php
@@ -136,10 +136,13 @@ class LogMessage
     }
 
     /**
-     * @param string $responseMessage
+     * @param string|null $responseMessage
      */
-    public function setResponseMessage(string $responseMessage): void
+    public function setResponseMessage(?string $responseMessage): void
     {
+        if (!$responseMessage) {
+            $responseMessage = '';
+        }
         $this->responseMessage = $responseMessage;
     }
 


### PR DESCRIPTION
setResponseMessage is called with a null argument.


[2021-07-13 14:22:27] OXID Logger.ERROR: Argument 1 passed to OxidProfessionalServices\AmazonPay\Core\Logger\LogMessage::setResponseMessage() must be of the type string, null given, acalled in /var/www/releases/oxid6/2021-07-13_11:59:40-live/vendor/oxid-professional-services/amazonpay/Core/Logger.php on line 74