### PR TITLE
Support amazon 'PayOnly'

### DIFF
--- a/Controller/Admin/ConfigController.php
+++ b/Controller/Admin/ConfigController.php
@@ -147,6 +147,10 @@ class ConfigController extends AdminController
             $conf['blAmazonPayMinicartAndModal'] = 0;
         }
 
+        if (!isset($conf['amazonPayType'])) {
+            $conf['amazonPayType'] = 'PayAndShip';
+        }
+
         return $conf;
     }
 

--- a/Controller/OrderController.php
+++ b/Controller/OrderController.php
@@ -54,15 +54,12 @@ class OrderController extends OrderController_parent
             $amazonService->isAmazonSessionActive()
         ) {
             $amazonSession = $amazonService->getCheckoutSession();
-            $country = oxNew(Country::class);
-            $countryOxId = $country->getIdByCode($amazonSession['response']['shippingAddress']['countryCode']);
-
             // Create guest user if not logged in
             if (!$user) {
                 $userComponent = oxNew(UserComponent::class);
                 $userComponent->createGuestUser($amazonSession);
 
-                $this->setAmazonPayAsPaymentMethod($countryOxId);
+                $this->setAmazonPayAsPaymentMethod();
                 Registry::getUtils()->redirect(Registry::getConfig()->getShopHomeUrl() . 'cl=order', false, 302);
             } else {
                 // if Amazon provides a shipping address use it
@@ -79,8 +76,7 @@ class OrderController extends OrderController_parent
                     }
                     $deliveryAddress = array_merge($mappedDeliveryFields, $missingDeliveryFields);
                     $session->setVariable('amazondeladr', $deliveryAddress);
-                    $countryOxId = $country->getIdByCode($amazonSession['response']['shippingAddress']['countryCode']);
-                    $this->setAmazonPayAsPaymentMethod($countryOxId);
+                    $this->setAmazonPayAsPaymentMethod();
                 }
                 // if amazon does not provide a shipping address and we already have an oxid user, use oxid-user-data
                 else {

--- a/Controller/OrderController.php
+++ b/Controller/OrderController.php
@@ -51,8 +51,7 @@ class OrderController extends OrderController_parent
         $amazonService = OxidServiceProvider::getAmazonService();
 
         if (!$exclude &&
-            $amazonService->isAmazonSessionActive() &&
-            $session->getVariable('paymentid') === 'oxidamazon'
+            $amazonService->isAmazonSessionActive()
         ) {
             $amazonSession = $amazonService->getCheckoutSession();
             $country = oxNew(Country::class);

--- a/Controller/OrderController.php
+++ b/Controller/OrderController.php
@@ -50,9 +50,9 @@ class OrderController extends OrderController_parent
         $exclude = $this->getViewConfig()->isAmazonExclude();
         $amazonService = OxidServiceProvider::getAmazonService();
 
-        if (
-            !$exclude &&
-            $amazonService->isAmazonSessionActive()
+        if (!$exclude &&
+            $amazonService->isAmazonSessionActive() &&
+            $session->getVariable('paymentid') === 'oxidamazon'
         ) {
             $amazonSession = $amazonService->getCheckoutSession();
             $country = oxNew(Country::class);
@@ -88,15 +88,7 @@ class OrderController extends OrderController_parent
                 $session->setVariable('amazondeladr', $deliveryAddress);
             }
         }
-
-        // security check, if we have Amazon as Payment-ID but no Amazon-Session, then something went wrong.
-        if (
-            $session->getVariable('paymentid') === 'oxidamazon' &&
-            !$amazonService->isAmazonSessionActive()
-        ) {
-            $amazonService->unsetPaymentMethod();
-            Registry::getUtils()->redirect(Registry::getConfig()->getShopHomeUrl() . 'cl=payment', false, 302);
-        }
+        
         parent::init();
     }
 

--- a/Controller/OrderController.php
+++ b/Controller/OrderController.php
@@ -98,6 +98,14 @@ class OrderController extends OrderController_parent
 
         if (
             $basket->getPaymentId() === 'oxidamazon' &&
+            !OxidServiceProvider::getAmazonService()->isAmazonSessionActive()
+        ) {
+            Registry::getUtilsView()->addErrorToDisplay('MESSAGE_PAYMENT_UNAVAILABLE_PAYMENT');
+            OxidServiceProvider::getAmazonService()->unsetPaymentMethod();
+            return;
+        }
+        else if (
+            $basket->getPaymentId() === 'oxidamazon' &&
             !$exclude &&
             OxidServiceProvider::getAmazonService()->isAmazonSessionActive()
         ) {

--- a/Controller/OrderController.php
+++ b/Controller/OrderController.php
@@ -96,69 +96,85 @@ class OrderController extends OrderController_parent
         $basket = $this->getSession()->getBasket();
         $exclude = $this->getViewConfig()->isAmazonExclude();
 
+        // if payment is 'oxidamazon' but we do not have a Amazon Pay Session
+        // or Amazon Pay is excluded stop executing order
         if (
-            $basket->getPaymentId() === 'oxidamazon' &&
-            !OxidServiceProvider::getAmazonService()->isAmazonSessionActive()
+            ($basket->getPaymentId() === 'oxidamazon' &&
+                !OxidServiceProvider::getAmazonService()->isAmazonSessionActive()) ||
+            $exclude
         ) {
             Registry::getUtilsView()->addErrorToDisplay('MESSAGE_PAYMENT_UNAVAILABLE_PAYMENT');
             OxidServiceProvider::getAmazonService()->unsetPaymentMethod();
             return;
         }
-        else if (
-            $basket->getPaymentId() === 'oxidamazon' &&
-            !$exclude &&
-            OxidServiceProvider::getAmazonService()->isAmazonSessionActive()
-        ) {
-            $payload = new Payload();
 
-            $orderOxId = Registry::getSession()->getVariable('sess_challenge');
-            $oOrder = oxNew(Order::class);
-            if ($oOrder->load($orderOxId)) {
-                $payload->setMerchantReferenceId($oOrder->oxorder__oxordernr->value);
-            }
-            $payload->setPaymentDetailsChargeAmount(PhpHelper::getMoneyValue(
-                $this->getBasket()->getPrice()->getBruttoPrice()
-            ));
-
-            $activeShop = Registry::getConfig()->getActiveShop();
-
-            $payload->setMerchantStoreName($activeShop->oxshops__oxcompany->value);
-            $payload->setNoteToBuyer($activeShop->oxshops__oxordersubject->value);
-
-            $amazonConfig = oxNew(Config::class);
-
-            $payload->setCurrencyCode($amazonConfig->getPresentmentCurrency());
-
-            if (OxidServiceProvider::getAmazonClient()->getModuleConfig()->isOneStepCapture()) {
-                $payload->setPaymentIntent('AuthorizeWithCapture');
-                $payload->setCanHandlePendingAuthorization(false);
-            } else {
-                $payload->setPaymentIntent('Authorize');
-                $payload->setCanHandlePendingAuthorization(true);
-            }
-
-            $result = OxidServiceProvider::getAmazonClient()->updateCheckoutSession(
-                OxidServiceProvider::getAmazonService()->getCheckoutSessionId(),
-                $payload->getData()
-            );
-
-            if (
-                isset($result['response']) &&
-                isset($result['status']) &&
-                $result['status'] === 200
-            ) {
-                $response = PhpHelper::jsonToArray($result['response']);
-                Registry::getUtils()->redirect(PhpHelper::getArrayValue('amazonPayRedirectUrl', $response), false, 301);
-            } else {
-                OxidServiceProvider::getAmazonService()->unsetPaymentMethod();
-                if ($oOrder->isLoaded()) {
-                    $oOrder->delete();
-                }
-                Registry::getUtils()->redirect(Registry::getConfig()->getShopHomeUrl() . 'cl=payment', false, 302);
+        // if payment is 'oxidamazon' call parent::execute to validate and finalize order
+        // then try to complete order at Amazon Pay
+        else if ($basket->getPaymentId() === 'oxidamazon' ) {
+            $ret = parent::execute();
+            // if order is validated and finalized complete Amazon Pay
+            if ($ret === 'thankyou' ) {
+                $this->completeAmazonPayment();
             }
         }
 
-        return parent::execute();
+        // in all other cases return parent
+        if (!$ret) {
+            $ret = parent::execute();
+        }
+        return $ret;
+    }
+
+    protected function completeAmazonPayment()
+    {
+        $payload = new Payload();
+        $orderOxId = Registry::getSession()->getVariable('sess_challenge');
+        $oOrder = oxNew(Order::class);
+        if ($oOrder->load($orderOxId)) {
+            $payload->setMerchantReferenceId($oOrder->oxorder__oxordernr->value);
+        }
+        $payload->setPaymentDetailsChargeAmount(PhpHelper::getMoneyValue(
+            $this->getBasket()->getPrice()->getBruttoPrice()
+        ));
+
+        $activeShop = Registry::getConfig()->getActiveShop();
+        $payload->setMerchantStoreName($activeShop->oxshops__oxcompany->value);
+        $payload->setNoteToBuyer($activeShop->oxshops__oxordersubject->value);
+
+        $amazonConfig = oxNew(Config::class);
+        $payload->setCurrencyCode($amazonConfig->getPresentmentCurrency());
+
+        if (OxidServiceProvider::getAmazonClient()->getModuleConfig()->isOneStepCapture()) {
+            $payload->setPaymentIntent('AuthorizeWithCapture');
+            $payload->setCanHandlePendingAuthorization(false);
+        } else {
+            $payload->setPaymentIntent('Authorize');
+            $payload->setCanHandlePendingAuthorization(true);
+        }
+
+        $result = OxidServiceProvider::getAmazonClient()->updateCheckoutSession(
+            OxidServiceProvider::getAmazonService()->getCheckoutSessionId(),
+            $payload->getData()
+        );
+
+        if (
+            isset($result['response']) &&
+            isset($result['status']) &&
+            $result['status'] === 200 &&
+            $oOrder->isLoaded() &&
+            !empty((PhpHelper::getArrayValue('amazonPayRedirectUrl', PhpHelper::jsonToArray($result['response']))))
+        ) {
+            $response = PhpHelper::jsonToArray($result['response']);
+            Registry::getUtils()->redirect(PhpHelper::getArrayValue('amazonPayRedirectUrl', $response), false, 301);
+        } else {
+            Registry::getUtilsView()->addErrorToDisplay('MESSAGE_PAYMENT_UNAVAILABLE_PAYMENT');
+            OxidServiceProvider::getAmazonService()->unsetPaymentMethod();
+            if ($oOrder && $oOrder->isLoaded()) {
+                $oOrder->delete();
+            }
+            Registry::getUtils()->redirect(Registry::getConfig()->getShopHomeUrl() . 'cl=payment', false, 302);
+        }
+
     }
 
     /**

--- a/Core/AmazonService.php
+++ b/Core/AmazonService.php
@@ -141,10 +141,7 @@ class AmazonService
 
         $checkoutSession = $this->getCheckoutSession();
 
-        return (
-            ($checkoutSession['response']['statusDetails']['state'] === Constants::CHECKOUT_OPEN) &&
-            (is_array($checkoutSession['response']['shippingAddress']))
-        );
+        return ($checkoutSession['response']['statusDetails']['state'] === Constants::CHECKOUT_OPEN);
     }
 
     /**

--- a/Core/AmazonService.php
+++ b/Core/AmazonService.php
@@ -191,7 +191,13 @@ class AmazonService
         $checkoutSession = $this->getCheckoutSession();
         $address = $checkoutSession['response']['shippingAddress'] ?? [];
 
-        return Address::mapAddressToView($address, 'oxaddress__');
+        // map address fields only if amazon response have a shippingAddress
+        if (!empty($address)) {
+            return Address::mapAddressToView($address, 'oxaddress__');
+        }
+        else {
+            return [];
+        }
     }
 
     /**

--- a/Core/Config.php
+++ b/Core/Config.php
@@ -416,7 +416,7 @@ class Config
      */
     public function getPayType(): string
     {
-        return Registry::getConfig()->getConfigParam('amazonPayType');
+        return Registry::getConfig()->getConfigParam('amazonPayType') ? Registry::getConfig()->getConfigParam('amazonPayType'): "PayAndShip";
     }
 
 }

--- a/Core/Config.php
+++ b/Core/Config.php
@@ -410,4 +410,13 @@ class Config
     {
         return Constants::PLATTFORM_ID;
     }
+
+    /**
+     * @return string
+     */
+    public function getPayType(): string
+    {
+        return Registry::getConfig()->getConfigParam('amazonPayType');
+    }
+
 }

--- a/Model/Order.php
+++ b/Model/Order.php
@@ -81,15 +81,17 @@ class Order extends Order_parent
      */
     public function getDelAddressInfo()
     {
+        $amazonService = $this->getAmazonService();
+        $amazonDelAddress = $amazonService->getDeliveryAddress();
         if (
-            !$this->getAmazonService()->isAmazonSessionActive() ||
-            !$this->getAmazonService()->getDeliveryAddress()
+            !$amazonService->isAmazonSessionActive() ||
+            !$amazonDelAddress
         ) {
             return parent::getDelAddressInfo();
         }
 
         $address = oxNew(Address::class);
-        $address->assign($this->getAmazonService()->getDeliveryAddress());
+        $address->assign($amazonDelAddress);
 
         // sanitized addresses for amazon-orders
         $config = Registry::get(Config::class);
@@ -136,9 +138,9 @@ class Order extends Order_parent
     public function getAmazonService(): AmazonService
     {
         if (empty($this->amazonService)) {
-            return oxNew(AmazonService::class);
+            $this->setAmazonService(oxNew(AmazonService::class));
+            return $this->amazonService;
         }
-
         return $this->amazonService;
     }
 

--- a/Model/Order.php
+++ b/Model/Order.php
@@ -81,7 +81,10 @@ class Order extends Order_parent
      */
     public function getDelAddressInfo()
     {
-        if (!$this->getAmazonService()->isAmazonSessionActive()) {
+        if (
+            !$this->getAmazonService()->isAmazonSessionActive() ||
+            !$this->getAmazonService()->getDeliveryAddress()
+        ) {
             return parent::getDelAddressInfo();
         }
 

--- a/metadata.php
+++ b/metadata.php
@@ -421,5 +421,6 @@ $aModule = [
         ['name' => 'blAmazonPayMinicartAndModal', 'type' => 'bool', 'value' => 'true', 'group' => null],
         ['name' => 'blAmazonPayUseExclusion', 'type' => 'bool', 'value' => 'false', 'group' => null],
         ['name' => 'amazonPayCapType', 'type' => 'str', 'value' => '', 'group' => null],
+        ['name' => 'amazonPayType', 'type' => 'str', 'value' => '', 'group' => null],
     ]
 ];

--- a/views/admin/de/admin_lang.php
+++ b/views/admin/de/admin_lang.php
@@ -76,5 +76,8 @@ $aLang = [
     'OXPS_AMAZONPAY_IPN_HISTORY'             => 'IPN-Historie',
     'OXPS_AMAZONPAY_DATE'                    => 'Datum',
     'OXPS_AMAZONPAY_REFERENCE'               => 'Referenz',
-    'OXPS_AMAZONPAY_RESULT'                  => 'Ergebnis'
+    'OXPS_AMAZONPAY_RESULT'                  => 'Ergebnis',
+
+    'OXPS_AMAZONPAY_PAYTYPE'            => 'AmazonPay Checkout Type',
+    'HELP_OXPS_AMAZONPAY_PAYTYPE'       => 'Auswahl Lieferadresse über Amazon Pay (PayAndShip) oder nur Zahlung über Amazon Pay (PayOnly)'
 ];

--- a/views/admin/en/admin_lang.php
+++ b/views/admin/en/admin_lang.php
@@ -75,5 +75,8 @@ $aLang = [
     'OXPS_AMAZONPAY_IPN_HISTORY'             => 'IPN-History',
     'OXPS_AMAZONPAY_DATE'                    => 'Date',
     'OXPS_AMAZONPAY_REFERENCE'               => 'Reference',
-    'OXPS_AMAZONPAY_RESULT'                  => 'Result'
+    'OXPS_AMAZONPAY_RESULT'                  => 'Result',
+
+    'OXPS_AMAZONPAY_PAYTYPE'            => 'AmazonPay Checkout Type',
+    'HELP_OXPS_AMAZONPAY_PAYTYPE'       => 'Selection of delivery address via Amazon Pay (PayAndShip) or only payment via Amazon Pay (PayOnly)'
 ];

--- a/views/admin/tpl/amazonconfig.tpl
+++ b/views/admin/tpl/amazonconfig.tpl
@@ -121,24 +121,42 @@
         </div>
 
         <div class="form-group jsonform-error-captureType">
-                    <label for="opmode">[{oxmultilang ident="OXPS_AMAZONPAY_CAPTYPE"}]</label>
-                    <div class="controls">
-                        <select name="conf[amazonPayCapType]" id="captype" class="form-control" required>
-                            <option value="">
-                                [{oxmultilang ident="OXPS_AMAZONPAY_PLEASE_CHOOSE"}]
-                            </option>
-                            <option value="1" [{if $config->isOneStepCapture()}]selected[{/if}]>
-                                [{oxmultilang ident="OXPS_AMAZONPAY_CAPTYPE_ONE_STEP"}]
-                            </option>
-                            <option value="2" [{if $config->isTwoStepCapture()}]selected[{/if}]>
-                                [{oxmultilang ident="OXPS_AMAZONPAY_CAPTYPE_TWO_STEP"}]
-                            </option>
-                        </select>
-                        <span class="help-block">[{oxmultilang ident="HELP_OXPS_AMAZONPAY_CAPTYPE"}]</span>
-                    </div>
-                </div>
+            <label for="opmode">[{oxmultilang ident="OXPS_AMAZONPAY_CAPTYPE"}]</label>
+            <div class="controls">
+                <select name="conf[amazonPayCapType]" id="captype" class="form-control" required>
+                    <option value="">
+                        [{oxmultilang ident="OXPS_AMAZONPAY_PLEASE_CHOOSE"}]
+                    </option>
+                    <option value="1" [{if $config->isOneStepCapture()}]selected[{/if}]>
+                        [{oxmultilang ident="OXPS_AMAZONPAY_CAPTYPE_ONE_STEP"}]
+                    </option>
+                    <option value="2" [{if $config->isTwoStepCapture()}]selected[{/if}]>
+                        [{oxmultilang ident="OXPS_AMAZONPAY_CAPTYPE_TWO_STEP"}]
+                    </option>
+                </select>
+                <span class="help-block">[{oxmultilang ident="HELP_OXPS_AMAZONPAY_CAPTYPE"}]</span>
+            </div>
+        </div>
 
-                <div class="form-group">
+        <div class="form-group jsonform-error-payType">
+            <label for="opmode">[{oxmultilang ident="OXPS_AMAZONPAY_PAYTYPE"}]</label>
+            <div class="controls">
+                <select name="conf[amazonPayType]" id="paytype" class="form-control" required>
+                    <option value="">
+                        [{oxmultilang ident="OXPS_AMAZONPAY_PLEASE_CHOOSE"}]
+                    </option>
+                    <option value="PayAndShip" [{if $config->getPayType() == 'PayAndShip'}]selected[{/if}]>
+                        PayAndShip
+                    </option>
+                    <option value="PayOnly" [{if $config->getPayType() == 'PayOnly'}]selected[{/if}]>
+                        PayOnly
+                    </option>
+                </select>
+                <span class="help-block">[{oxmultilang ident="HELP_OXPS_AMAZONPAY_PAYTYPE"}]</span>
+            </div>
+        </div>
+
+        <div class="form-group">
             <button type="submit" class="btn btn-default bottom-space">[{oxmultilang ident="OXPS_AMAZONPAY_SAVE"}]</button>
         </div>
     </form>

--- a/views/elements/amazonbutton.tpl
+++ b/views/elements/amazonbutton.tpl
@@ -9,7 +9,7 @@
         sandbox: [{if $amazonConfig->isSandbox()}]true[{else}]false[{/if}],
         ledgerCurrency: '[{$amazonConfig->getLedgerCurrency()}]',
         checkoutLanguage: '[{$amazonConfig->getCheckoutLanguage()}]',
-        productType: 'PayAndShip',
+        productType: [{if $amazonConfig->getPayType()}]'[{$amazonConfig->getPayType()}]'[{else}]'PayAndShip'[{/if}],
         placement: 'Cart'
     });
 [{/capture}]


### PR DESCRIPTION
if someone wants to use Amazon Pay in "PayOnly" mode:
-> Amazon will not sent a shipping address in its api-response (The answer from Amazon is nevertheless valid -> therefore adjustment in AmazonService::isAmazonSessionActive())
-> So do not try to use (empty) shipping address
-> use OXID shipping address or user's billing address instead
-> make AmazonPay checkout type configurable ('PayAndShip' as default / 'PayOnly' as option)