### PR TITLE
Mark order as paid

### DIFF
--- a/Core/Events.php
+++ b/Core/Events.php
@@ -41,6 +41,7 @@ class Events
         self::enablePaymentMethod();
         self::addArticleColumn();
         self::addCategoryColumn();
+        self::addOrderColumn();
 
         $dbMetaDataHandler = oxNew(DbMetaDataHandler::class);
         $dbMetaDataHandler->updateViews();
@@ -107,6 +108,28 @@ class Events
                 'ALTER TABLE %s ADD COLUMN OXPS_AMAZON_CARRIER VARCHAR (100)',
                 'oxdeliveryset'
             );
+
+            DatabaseProvider::getDb()->execute($sql);
+        }
+    }
+
+    public static function addOrderColumn(): void
+    {
+        $viewNameGenerator = Registry::get(\OxidEsales\Eshop\Core\TableViewNameGenerator::class);
+
+        $sql = 'SELECT COLUMN_NAME
+                FROM information_schema.COLUMNS
+                WHERE TABLE_NAME = \'' . $viewNameGenerator->getViewName('oxorder') . '\'
+                AND COLUMN_NAME = \'OXPS_AMAZON_REMARK\'';
+
+        $result = DatabaseProvider::getDb(DatabaseProvider::FETCH_MODE_ASSOC)->getAll($sql);
+
+        if (count($result) === 0) {
+            $sql = 'ALTER TABLE `oxorder` ADD COLUMN `OXPS_AMAZON_REMARK`
+                                varchar(32) 
+                                NOT NULL
+                                DEFAULT ""
+                                COMMENT \'Remark from amazonpay\'';
 
             DatabaseProvider::getDb()->execute($sql);
         }

--- a/Core/Repository/LogRepository.php
+++ b/Core/Repository/LogRepository.php
@@ -177,7 +177,7 @@ class LogRepository
      */
     public function markOrderPaid($orderId, $remark, $transStatus = 'OK', $chargeId = ''): void
     {
-        $sql = 'UPDATE oxorder SET OXPAID = ?, OXTRANSSTATUS = ?, OXREMARK = ?, OXTRANSID= ? WHERE OXID=?';
+        $sql = 'UPDATE oxorder SET OXPAID = ?, OXTRANSSTATUS = ?, OXPS_AMAZON_REMARK = ?, OXTRANSID= ? WHERE OXID=?';
         DatabaseProvider::getDb(DatabaseProvider::FETCH_MODE_ASSOC)->execute(
             $sql,
             [

--- a/metadata.php
+++ b/metadata.php
@@ -399,6 +399,12 @@ $aModule = [
             'position' => '5'
         ],
         [
+            'template' => 'order_overview.tpl',
+            'block' => 'admin_order_overview_checkout',
+            'file' => 'views/blocks/admin/admin_order_overview_checkout.tpl',
+            'position' => '5'
+        ],
+        [
             'template' => 'article_main.tpl',
             'block' => 'admin_article_main_extended',
             'file' => 'views/blocks/admin/admin_article_main_extended.tpl',

--- a/translations/de/oxpsamazonpay_de_lang.php
+++ b/translations/de/oxpsamazonpay_de_lang.php
@@ -40,5 +40,6 @@ $aLang = [
     'AMAZON_PAY_COMPLETECHECKOUTSESSION_ERROR_SUBJECT' => 'Fehler beim finalisieren einer Amazon-Order',
     'AMAZON_PAY_COMPLETECHECKOUTSESSION_ERROR_MESSAGE' => 'Der Versuch die Order %s bei Amazon zu finalisieren, schlug fehl. Bitte prüfe die Order und die Informationen aus Ihrem Amazon-Account.',
     'AMAZON_PAY_LASTSHIPSETNOTVALID'          => 'Die von Ihnen gewählte Versandart ist bei Zahlung über Amazon Pay nicht möglich. Die Versandart wurde zurückgesetzt.',
-    'AMAZON_PAY_BILLINGCOUNTRY_MISMATCH'      => 'Das Land der Amazon-Rechnungsadresse passt nicht zu den erlaubten Ländern des Shops. Daher wird die Amazon-Lieferadresse als Rechnungsadresse übernommen.'
+    'AMAZON_PAY_BILLINGCOUNTRY_MISMATCH'      => 'Das Land der Amazon-Rechnungsadresse passt nicht zu den erlaubten Ländern des Shops. Daher wird die Amazon-Lieferadresse als Rechnungsadresse übernommen.',
+    'AMAZON_PAY_REMARK'                       => 'Amazon Pay Mitteillung:'
 ];

--- a/translations/en/oxpsamazonpay_en_lang.php
+++ b/translations/en/oxpsamazonpay_en_lang.php
@@ -40,5 +40,6 @@ $aLang = [
     'AMAZON_PAY_COMPLETECHECKOUTSESSION_ERROR_SUBJECT' => 'Error finalizing an Amazon order',
     'AMAZON_PAY_COMPLETECHECKOUTSESSION_ERROR_MESSAGE' => 'The attempt to finalize the order %s at Amazon failed. Please check the order and the information from your Amazon account.',
     'AMAZON_PAY_LASTSHIPSETNOTVALID'          => 'The shipping method you have selected is not possible when paying via Amazon Pay. The shipping method has been reset.',
-    'AMAZON_PAY_BILLINGCOUNTRY_MISMATCH'      => 'The country of the Amazon billing address does not match the allowed countries of the shop. Therefore, the Amazon delivery address is used as the billing address.'
+    'AMAZON_PAY_BILLINGCOUNTRY_MISMATCH'      => 'The country of the Amazon billing address does not match the allowed countries of the shop. Therefore, the Amazon delivery address is used as the billing address.',
+    'AMAZON_PAY_REMARK'                       => 'Amazon Pay notice:',
 ];

--- a/views/admin/de/admin_lang.php
+++ b/views/admin/de/admin_lang.php
@@ -76,5 +76,6 @@ $aLang = [
     'OXPS_AMAZONPAY_IPN_HISTORY'             => 'IPN-Historie',
     'OXPS_AMAZONPAY_DATE'                    => 'Datum',
     'OXPS_AMAZONPAY_REFERENCE'               => 'Referenz',
-    'OXPS_AMAZONPAY_RESULT'                  => 'Ergebnis'
+    'OXPS_AMAZONPAY_RESULT'                  => 'Ergebnis',
+    'AMAZON_PAY_REMARK'                       => 'Amazon Pay Mitteillung:'
 ];

--- a/views/admin/en/admin_lang.php
+++ b/views/admin/en/admin_lang.php
@@ -75,5 +75,6 @@ $aLang = [
     'OXPS_AMAZONPAY_IPN_HISTORY'             => 'IPN-History',
     'OXPS_AMAZONPAY_DATE'                    => 'Date',
     'OXPS_AMAZONPAY_REFERENCE'               => 'Reference',
-    'OXPS_AMAZONPAY_RESULT'                  => 'Result'
+    'OXPS_AMAZONPAY_RESULT'                  => 'Result',
+    'AMAZON_PAY_REMARK'                       => 'Amazon Pay notice:',
 ];

--- a/views/blocks/admin/admin_order_overview_checkout.tpl
+++ b/views/blocks/admin/admin_order_overview_checkout.tpl
@@ -1,0 +1,7 @@
+[{$smarty.block.parent}]
+[{if $edit->oxorder__oxpaymenttype->value == 'oxidamazon'}]
+    <tr>
+        <td class="edittext"><b>[{oxmultilang ident="AMAZON_PAY_REMARK"}]:</b></td>
+        <td class="edittext">[{$edit->oxorder__oxps_amazon_remark->value}]<br></td>
+    </tr>
+[{/if}]


### PR DESCRIPTION
fix: do not override oxorder.oxremark

- The message written by a customer during the ordering process may not be overwritten
- A customer message (some value in oxremark) causes most ERP-systems to stop the automated processing of the order


[screen.pdf](https://github.com/OXID-eSales/amazon-pay-module/files/8564254/screen.pdf)