### PR TITLE
Finalize order - optimized handling of orderstatus before / after capturing

### DIFF
--- a/Core/AmazonService.php
+++ b/Core/AmazonService.php
@@ -291,7 +291,16 @@ class AmazonService
         $paymentCC->save();
     }
 
-    public function processOneStepPayment($amazonSessionId, Basket $basket, LoggerInterface $logger): void
+    /**
+     * Processing Amazon Pay
+     *
+     * @param $amazonSessionId
+     * @param \OxidEsales\Eshop\Application\Model\Basket $oBasket Basket object
+     * @param \Psr\Log\LoggerInterface $logger Logger
+     * @param bool $bl2Step
+     *
+     */
+    protected function processPayment($amazonSessionId, Basket $basket, LoggerInterface $logger, $bl2Step = false): void
     {
         $amazonConfig = oxNew(Config::class);
 
@@ -302,11 +311,11 @@ class AmazonService
 
         $payload->setMerchantStoreName($activeShop->oxshops__oxcompany->value);
         $payload->setNoteToBuyer($activeShop->oxshops__oxordersubject->value);
-
         $payload->setCurrencyCode($amazonConfig->getPresentmentCurrency());
 
         $data = $payload->removeMerchantMetadata($payload->getData());
 
+        // call Amazon Pay
         $result = OxidServiceProvider::getAmazonClient()->completeCheckoutSession(
             $amazonSessionId,
             $data
@@ -314,7 +323,7 @@ class AmazonService
 
         $response = PhpHelper::jsonToArray($result['response']);
 
-        if ($response['statusDetails']['state'] === 'Completed') {
+        if ($response['statusDetails']['state'] === 'Completed' && !$bl2Step) {
             $response['statusDetails']['state'] = 'Completed & Captured';
         }
 
@@ -322,87 +331,64 @@ class AmazonService
 
         Registry::getSession()->deleteVariable(Constants::SESSION_CHECKOUT_ID);
         $request = PhpHelper::jsonToArray($result['request']);
-        $repository = oxNew(LogRepository::class);
 
-        if ($result['status'] === 200) {
-            $repository->markOrderPaid(
-                $basket->getOrderId(),
-                'AmazonPay: ' . $request['chargeAmount']['amount'],
-                'OK',
-                $response['chargeId']
-            );
-
-            Registry::getUtils()->redirect(Registry::getConfig()->getShopHomeUrl() . 'cl=thankyou', true, 302);
-        } elseif ($result['status'] === 202) {
-            $repository->updateOrderStatus(
-                'AmazonPay: ' . $request['chargeAmount']['amount'],
-                'NOT_FINISHED',
-                $response['chargeId']
-            );
-
-            Registry::getUtils()->redirect(Registry::getConfig()->getShopHomeUrl() . 'cl=thankyou', true, 302);
-        } else {
-            $repository->updateOrderStatus(
-                $basket->getOrderId(),
-                'ERROR',
-                $response['chargeId']
-            );
-
-            $this->showErrorOnRedirect($logger, $result, $basket->getOrderId());
+        $order = oxNew(Order::class);
+        if ($order->load($basket->getOrderId())) {
+            if ($result['status'] === 200) {
+                $data = array(
+                    "chargeAmount" => $request['chargeAmount']['amount'],
+                    "chargeId" => $response['chargeId']
+                );
+                if(!$bl2Step) {
+                    $order->updateAmazonPayOrderStatus('AMZ_AUTH_AND_CAPT_OK', $data);
+                }
+                else{
+                    $order->updateAmazonPayOrderStatus('AMZ_2STEP_AUTH_OK', $data);
+                }
+                Registry::getUtils()->redirect(Registry::getConfig()->getShopHomeUrl() . 'cl=thankyou', true, 302);
+            } elseif ($result['status'] === 202) {
+                $data = array(
+                    "chargeAmount" => $request['chargeAmount']['amount'],
+                    "chargeId" => $response['chargeId']
+                );
+                $order->updateAmazonPayOrderStatus('AMZ_AUTH_STILL_PENDING', $data);
+                Registry::getUtils()->redirect(Registry::getConfig()->getShopHomeUrl() . 'cl=thankyou', true, 302);
+            } else {
+                $data = array(
+                    "result" => $result,
+                    "chargeId" => $response['chargeId']
+                );
+                $order->updateAmazonPayOrderStatus('AMZ_AUTH_AND_CAPT_FAILED', $data);
+                $this->showErrorOnRedirect($logger, $result, $basket->getOrderId());
+            }
         }
+        $this->showErrorOnRedirect($logger, $result, $basket->getOrderId());
     }
 
+    /**
+     * Processing Amazon Pay Auth an Capt
+     *
+     * @param $amazonSessionId
+     * @param \OxidEsales\Eshop\Application\Model\Basket $oBasket Basket object
+     * @param \Psr\Log\LoggerInterface $logger Logger
+     *
+     */
+    public function processOneStepPayment($amazonSessionId, Basket $basket, LoggerInterface $logger): void
+    {
+        $this->processPayment($amazonSessionId, $basket, $logger, false);
+    }
+
+    /**
+     * Processing Amazon Pay Auth
+     *
+     * @param $amazonSessionId
+     * @param \OxidEsales\Eshop\Application\Model\Basket $oBasket Basket object
+     * @param \Psr\Log\LoggerInterface $logger Logger
+     *
+     */
     public function processTwoStepPayment($amazonSessionId, Basket $basket, LoggerInterface $logger): void
     {
-        $amazonConfig = oxNew(Config::class);
-
-        $amount = PhpHelper::getMoneyValue($basket->getPrice()->getBruttoPrice());
-        $payload = new Payload();
-        $payload->setCheckoutChargeAmount($amount);
-
-        $activeShop = Registry::getConfig()->getActiveShop();
-
-        $payload->setMerchantStoreName($activeShop->oxshops__oxcompany->value);
-        $payload->setNoteToBuyer($activeShop->oxshops__oxordersubject->value);
-
-        $payload->setCurrencyCode($amazonConfig->getPresentmentCurrency());
-
-        $data = $payload->removeMerchantMetadata($payload->getData());
-
-        $result = OxidServiceProvider::getAmazonClient()->completeCheckoutSession(
-            $amazonSessionId,
-            $data
-        );
-
-        $response = PhpHelper::jsonToArray($result['response']);
-        $repository = oxNew(LogRepository::class);
-        $logger->info($response['statusDetails']['state'], $result);
-        Registry::getSession()->deleteVariable(Constants::SESSION_CHECKOUT_ID);
-
-        if ($result['status'] === 200) {
-            $repository->updateOrderStatus(
-                $basket->getOrderId(),
-                'AMZ-Authorize-Open',
-                $response['chargeId']
-            );
-            Registry::getUtils()->redirect(Registry::getConfig()->getShopHomeUrl() . 'cl=thankyou', true, 302);
-        } elseif ($result['status'] === 202) {
-            $repository->updateOrderStatus(
-                $basket->getOrderId(),
-                'AMZ-Authorize-Pending',
-                $response['chargeId']
-            );
-            Registry::getUtils()->redirect(Registry::getConfig()->getShopHomeUrl() . 'cl=thankyou', true, 302);
-        } else {
-            $repository->updateOrderStatus(
-                $basket->getOrderId(),
-                'ERROR',
-                $response['chargeId']
-            );
-
-            $result['message'] = 'Auth error - please select a different payment method';
-            $this->showErrorOnRedirect($logger, $result, $basket->getOrderId());
-        }
+        $this->processPayment($amazonSessionId, $basket, $logger,true);
     }
 
     /**

--- a/Core/Events.php
+++ b/Core/Events.php
@@ -41,6 +41,7 @@ class Events
         self::enablePaymentMethod();
         self::addArticleColumn();
         self::addCategoryColumn();
+        self::addOrderColumn();
 
         $dbMetaDataHandler = oxNew(DbMetaDataHandler::class);
         $dbMetaDataHandler->updateViews();
@@ -107,6 +108,28 @@ class Events
                 'ALTER TABLE %s ADD COLUMN OXPS_AMAZON_CARRIER VARCHAR (100)',
                 'oxdeliveryset'
             );
+
+            DatabaseProvider::getDb()->execute($sql);
+        }
+    }
+
+    public static function addOrderColumn(): void
+    {
+        $viewNameGenerator = Registry::get(\OxidEsales\Eshop\Core\TableViewNameGenerator::class);
+
+        $sql = 'SELECT COLUMN_NAME
+                FROM information_schema.COLUMNS
+                WHERE TABLE_NAME = \'' . $viewNameGenerator->getViewName('oxorder') . '\'
+                AND COLUMN_NAME = \'OXPS_AMAZON_REMARK\'';
+
+        $result = DatabaseProvider::getDb(DatabaseProvider::FETCH_MODE_ASSOC)->getAll($sql);
+
+        if (count($result) === 0) {
+            $sql = 'ALTER TABLE `oxorder` ADD COLUMN `OXPS_AMAZON_REMARK`
+                                varchar(32) 
+                                NOT NULL
+                                DEFAULT ""
+                                COMMENT \'Remark from amazonpay\'';
 
             DatabaseProvider::getDb()->execute($sql);
         }

--- a/Core/Events.php
+++ b/Core/Events.php
@@ -126,7 +126,7 @@ class Events
 
         if (count($result) === 0) {
             $sql = 'ALTER TABLE `oxorder` ADD COLUMN `OXPS_AMAZON_REMARK`
-                                varchar(32) 
+                                varchar(256) 
                                 NOT NULL
                                 DEFAULT ""
                                 COMMENT \'Remark from amazonpay\'';

--- a/Core/Events.php
+++ b/Core/Events.php
@@ -126,7 +126,7 @@ class Events
 
         if (count($result) === 0) {
             $sql = 'ALTER TABLE `oxorder` ADD COLUMN `OXPS_AMAZON_REMARK`
-                                varchar(256) 
+                                varchar(255) 
                                 NOT NULL
                                 DEFAULT ""
                                 COMMENT \'Remark from amazonpay\'';

--- a/Core/Repository/LogRepository.php
+++ b/Core/Repository/LogRepository.php
@@ -177,7 +177,7 @@ class LogRepository
      */
     public function markOrderPaid($orderId, $remark, $transStatus = 'OK', $chargeId = ''): void
     {
-        $sql = 'UPDATE oxorder SET OXPAID = ?, OXTRANSSTATUS = ?, OXREMARK = ?, OXTRANSID= ? WHERE OXID=?';
+        $sql = 'UPDATE oxorder SET OXPAID = ?, OXTRANSSTATUS = ?, OXPS_AMAZON_REMARK = ?, OXTRANSID= ? WHERE OXID=?';
         DatabaseProvider::getDb(DatabaseProvider::FETCH_MODE_ASSOC)->execute(
             $sql,
             [

--- a/Model/Order.php
+++ b/Model/Order.php
@@ -164,7 +164,7 @@ class Order extends Order_parent
                 $this->oxorder__oxtransstatus = new Field('NOT_FINISHED', Field::T_RAW);
                 $this->oxorder__oxtransid = new Field('AMZ_PAYMENT_PENDING', Field::T_RAW);
                 $this->oxorder__oxfolder = new Field('ORDERFOLDER_PROBLEMS', Field::T_RAW);
-                $this->oxorder__oxps_amazon_remark = new Field('AMZ_PAYMENT_PENDING', Field::T_RAW);
+                $this->oxorder__oxps_amazon_remark = new Field('AmazonPay Authorisation pending', Field::T_RAW);
                 $this->save();
                 break;
 
@@ -182,7 +182,7 @@ class Order extends Order_parent
                     if ($data['chargeId']) {
                         $this->oxorder__oxtransid = new Field($data['chargeId'], Field::T_RAW);
                     }
-                    $this->oxorder__oxps_amazon_remark = new Field('AmazonPay: ' . $response['reasonCode'], Field::T_RAW);
+                    $this->oxorder__oxps_amazon_remark = new Field('AmazonPay ERROR: ' . $response['reasonCode'], Field::T_RAW);
                 }
                 else {
                     $this->oxorder__oxps_amazon_remark = new Field('AmazonPay: ERROR');
@@ -204,7 +204,7 @@ class Order extends Order_parent
             case "AMZ_2STEP_AUTH_OK":
                 if (is_array($data)) {
                     $this->oxorder__oxtransid = new Field($data['chargeId'], Field::T_RAW);
-                    $this->oxorder__oxps_amazon_remark = new Field('AmazonPay Authorized (not captured):' . $data['chargeAmount'], Field::T_RAW);
+                    $this->oxorder__oxps_amazon_remark = new Field('AmazonPay Authorized (not Captured):' . $data['chargeAmount'], Field::T_RAW);
                 }
                 $this->oxorder__oxfolder = new Field('ORDERFOLDER_NEW', Field::T_RAW);
                 $this->save();

--- a/Model/Order.php
+++ b/Model/Order.php
@@ -29,6 +29,7 @@ use OxidEsales\Eshop\Application\Model\RequiredAddressFields;
 use OxidEsales\Eshop\Application\Model\Basket;
 use OxidProfessionalServices\AmazonPay\Core\Config;
 use OxidProfessionalServices\AmazonPay\Core\AmazonService;
+use OxidProfessionalServices\AmazonPay\Core\Provider\OxidServiceProvider;
 
 /**
  * @mixin \OxidEsales\Eshop\Application\Model\Order
@@ -103,8 +104,8 @@ class Order extends Order_parent
             $oBasket->getPaymentId() === 'oxidamazon'
         ) {
             $this->_setOrderStatus('NOT_FINISHED');
-            $this->oxorder__oxtransid = new oxField('PAYMENT_PENDING');
-            $this->oxorder__oxfolder = new oxField('ORDERFOLDER_PROBLEMS');
+            $this->oxorder__oxtransid = new Field('PAYMENT_PENDING');
+            $this->oxorder__oxfolder = new Field('ORDERFOLDER_PROBLEMS');
             $this->save();
         }
         return $ret;

--- a/Model/Order.php
+++ b/Model/Order.php
@@ -103,11 +103,7 @@ class Order extends Order_parent
             !$blRecalculatingOrder &&
             $oBasket->getPaymentId() === 'oxidamazon'
         ) {
-            $this->_setOrderStatus('NOT_FINISHED');
-            $this->oxorder__oxtransid = new Field('PAYMENT_PENDING', Field::T_RAW);
-            $this->oxorder__oxfolder = new Field('ORDERFOLDER_PROBLEMS', Field::T_RAW);
-            $this->oxorder__oxps_amazon_remark = new Field('PAYMENT PENDING', Field::T_RAW);
-            $this->save();
+            $this->updateAmazonPayOrderStatus('AMZ_PAYMENT_PENDING');
         }
         return $ret;
     }
@@ -160,9 +156,27 @@ class Order extends Order_parent
         return 0; // disable validation
     }
 
-    public function updateStatus($status)
+    protected function updateAmazonPayOrderStatus($amazonPayStatus)
     {
-        $this->__set('OXTRANSTATUS', $status);
+        switch ($amazonPayStatus) {
+            case "AMZ_PAYMENT_PENDING":
+                $this->oxorder__oxtransstatus = new Field('NOT_FINISHED', Field::T_RAW);
+                $this->oxorder__oxtransid = new Field('AMZ_PAYMENT_PENDING', Field::T_RAW);
+                $this->oxorder__oxfolder = new Field('ORDERFOLDER_PROBLEMS', Field::T_RAW);
+                $this->oxorder__oxps_amazon_remark = new Field('AMZ_PAYMENT_PENDING', Field::T_RAW);
+                $this->save();
+                break;
+            case "AMZ_AUTH_STILL_PENDING":
+                break;
+            case "AMZ_AUTH_FAILED":
+                break;
+            case "AMZ_AUTH_OK":
+                break;
+            case "AMZ_AUTH_AND_CAPT_FAILED":
+                break;
+            case "AMZ_AUTH_AND_CAPT_OK":
+                break;
+        }
     }
 
     /**

--- a/Model/Order.php
+++ b/Model/Order.php
@@ -202,10 +202,9 @@ class Order extends Order_parent
                 break;
 
             case "AMZ_2STEP_AUTH_OK":
-                $this->oxorder__oxtransstatus = new Field('OK', Field::T_RAW);
                 if (is_array($data)) {
                     $this->oxorder__oxtransid = new Field($data['chargeId'], Field::T_RAW);
-                    $this->oxorder__oxps_amazon_remark = new Field('AMZ-Authorize-Open OK', Field::T_RAW);
+                    $this->oxorder__oxps_amazon_remark = new Field('AmazonPay Authorized (not captured):' . $data['chargeAmount'], Field::T_RAW);
                 }
                 $this->oxorder__oxfolder = new Field('ORDERFOLDER_NEW', Field::T_RAW);
                 $this->save();

--- a/Model/Order.php
+++ b/Model/Order.php
@@ -104,8 +104,9 @@ class Order extends Order_parent
             $oBasket->getPaymentId() === 'oxidamazon'
         ) {
             $this->_setOrderStatus('NOT_FINISHED');
-            $this->oxorder__oxtransid = new Field('PAYMENT_PENDING');
-            $this->oxorder__oxfolder = new Field('ORDERFOLDER_PROBLEMS');
+            $this->oxorder__oxtransid = new Field('PAYMENT_PENDING', Field::T_RAW);
+            $this->oxorder__oxfolder = new Field('ORDERFOLDER_PROBLEMS', Field::T_RAW);
+            $this->oxorder__oxps_amazon_remark = new Field('PAYMENT PENDING', Field::T_RAW);
             $this->save();
         }
         return $ret;

--- a/Model/Order.php
+++ b/Model/Order.php
@@ -157,7 +157,7 @@ class Order extends Order_parent
         return 0; // disable validation
     }
 
-    protected function updateAmazonPayOrderStatus($amazonPayStatus, $data = null)
+    public function updateAmazonPayOrderStatus($amazonPayStatus, $data = null)
     {
         switch ($amazonPayStatus) {
             case "AMZ_PAYMENT_PENDING":

--- a/metadata.php
+++ b/metadata.php
@@ -399,6 +399,12 @@ $aModule = [
             'position' => '5'
         ],
         [
+            'template' => 'order_overview.tpl',
+            'block' => 'admin_order_overview_checkout',
+            'file' => 'views/blocks/admin/admin_order_overview_checkout.tpl',
+            'position' => '5'
+        ],
+        [
             'template' => 'article_main.tpl',
             'block' => 'admin_article_main_extended',
             'file' => 'views/blocks/admin/admin_article_main_extended.tpl',

--- a/translations/de/oxpsamazonpay_de_lang.php
+++ b/translations/de/oxpsamazonpay_de_lang.php
@@ -40,5 +40,6 @@ $aLang = [
     'AMAZON_PAY_COMPLETECHECKOUTSESSION_ERROR_SUBJECT' => 'Fehler beim finalisieren einer Amazon-Order',
     'AMAZON_PAY_COMPLETECHECKOUTSESSION_ERROR_MESSAGE' => 'Der Versuch die Order %s bei Amazon zu finalisieren, schlug fehl. Bitte prüfe die Order und die Informationen aus Ihrem Amazon-Account.',
     'AMAZON_PAY_LASTSHIPSETNOTVALID'          => 'Die von Ihnen gewählte Versandart ist bei Zahlung über Amazon Pay nicht möglich. Die Versandart wurde zurückgesetzt.',
-    'AMAZON_PAY_BILLINGCOUNTRY_MISMATCH'      => 'Das Land der Amazon-Rechnungsadresse passt nicht zu den erlaubten Ländern des Shops. Daher wird die Amazon-Lieferadresse als Rechnungsadresse übernommen.'
+    'AMAZON_PAY_BILLINGCOUNTRY_MISMATCH'      => 'Das Land der Amazon-Rechnungsadresse passt nicht zu den erlaubten Ländern des Shops. Daher wird die Amazon-Lieferadresse als Rechnungsadresse übernommen.',
+    'AMAZON_PAY_REMARK'                       => 'Amazon Pay Mitteillung:'
 ];

--- a/translations/en/oxpsamazonpay_en_lang.php
+++ b/translations/en/oxpsamazonpay_en_lang.php
@@ -40,5 +40,6 @@ $aLang = [
     'AMAZON_PAY_COMPLETECHECKOUTSESSION_ERROR_SUBJECT' => 'Error finalizing an Amazon order',
     'AMAZON_PAY_COMPLETECHECKOUTSESSION_ERROR_MESSAGE' => 'The attempt to finalize the order %s at Amazon failed. Please check the order and the information from your Amazon account.',
     'AMAZON_PAY_LASTSHIPSETNOTVALID'          => 'The shipping method you have selected is not possible when paying via Amazon Pay. The shipping method has been reset.',
-    'AMAZON_PAY_BILLINGCOUNTRY_MISMATCH'      => 'The country of the Amazon billing address does not match the allowed countries of the shop. Therefore, the Amazon delivery address is used as the billing address.'
+    'AMAZON_PAY_BILLINGCOUNTRY_MISMATCH'      => 'The country of the Amazon billing address does not match the allowed countries of the shop. Therefore, the Amazon delivery address is used as the billing address.',
+    'AMAZON_PAY_REMARK'                       => 'Amazon Pay notice:',
 ];

--- a/views/admin/de/admin_lang.php
+++ b/views/admin/de/admin_lang.php
@@ -76,5 +76,6 @@ $aLang = [
     'OXPS_AMAZONPAY_IPN_HISTORY'             => 'IPN-Historie',
     'OXPS_AMAZONPAY_DATE'                    => 'Datum',
     'OXPS_AMAZONPAY_REFERENCE'               => 'Referenz',
-    'OXPS_AMAZONPAY_RESULT'                  => 'Ergebnis'
+    'OXPS_AMAZONPAY_RESULT'                  => 'Ergebnis',
+    'AMAZON_PAY_REMARK'                       => 'Amazon Pay Mitteillung:'
 ];

--- a/views/admin/en/admin_lang.php
+++ b/views/admin/en/admin_lang.php
@@ -75,5 +75,6 @@ $aLang = [
     'OXPS_AMAZONPAY_IPN_HISTORY'             => 'IPN-History',
     'OXPS_AMAZONPAY_DATE'                    => 'Date',
     'OXPS_AMAZONPAY_REFERENCE'               => 'Reference',
-    'OXPS_AMAZONPAY_RESULT'                  => 'Result'
+    'OXPS_AMAZONPAY_RESULT'                  => 'Result',
+    'AMAZON_PAY_REMARK'                       => 'Amazon Pay notice:',
 ];

--- a/views/blocks/admin/admin_order_overview_checkout.tpl
+++ b/views/blocks/admin/admin_order_overview_checkout.tpl
@@ -1,0 +1,7 @@
+[{$smarty.block.parent}]
+[{if $edit->oxorder__oxpaymenttype->value == 'oxidamazon'}]
+    <tr>
+        <td class="edittext"><b>[{oxmultilang ident="AMAZON_PAY_REMARK"}]:</b></td>
+        <td class="edittext">[{$edit->oxorder__oxps_amazon_remark->value}]<br></td>
+    </tr>
+[{/if}]


### PR DESCRIPTION
- increase safety and cleanup before/after finalizeOrder
- optimize handling of orderstatus after capturing order via Amazon Pay

Authorize and Capture via Amazon Pay (oxps_amazonpay module) will be done after finalizeOrder.
Therefore we reset status of order to "not finished yet" before Authorize and Capture is done.
After capturing we update order status to "finished"