### PR TITLE
fix: set user address id

### DIFF
--- a/Model/User.php
+++ b/Model/User.php
@@ -46,6 +46,7 @@ class User extends User_parent
 
             if ($service->isAmazonSessionActive()
                 && Registry::getConfig()->getTopActiveView()->getIsOrderStep()
+                && $service->getDeliveryAddress()
             ) {
                 $address = oxNew(Address::class);
                 $address->assign($service->getDeliveryAddress());


### PR DESCRIPTION
Do not set the ID of the (OXID) user's delivery address to "amazonPaymentDeliveryAddress" if the Amazon Checkout session does not contain any address data.

Note: The "Amazon Checkout Session" becomes active as soon as the user is redirected to Amazon. However, if the user does not log in to Amazon, the session cannot contain any address data.
If the user now uses the back button of the browser, the "Amazon Checkout Session" is still active (without address data).
-> The user's address ID (in OXID) may only be set to "amazonPaymentDeliveryAddress" if Amazon actually supplies address data.