### PR TITLE
PSAPC-171 move deleting deladrid in session to where payment is chosen

### DIFF
--- a/metadata.php
+++ b/metadata.php
@@ -40,6 +40,8 @@ use OxidSolutionCatalysts\AmazonPay\Model\Basket as ModuleBasket;
 use OxidSolutionCatalysts\AmazonPay\Model\Category as ModuleCategory;
 use OxidSolutionCatalysts\AmazonPay\Model\Order as ModuleOrder;
 use OxidSolutionCatalysts\AmazonPay\Model\User as ModuleUser;
+use OxidSolutionCatalysts\AmazonPay\Controller\PaymentController;
+use OxidEsales\Eshop\Application\Controller\PaymentController as CorePaymentController;
 
 $sMetadataVersion = '2.1';
 
@@ -65,6 +67,7 @@ $aModule = [
         CoreViewConfig::class => ViewConfig::class,
         CoreUserController::class => UserController::class,
         CoreOrderController::class => OrderController::class,
+        CorePaymentController::class => PaymentController::class,
         CoreArticleDetailsController::class => ArticleDetailsController::class,
         CoreOrderOverviewmodel::class => ModuleOrderOverview::class,
         CoreOrderArticleModel::class => ModuleOrderArticle::class,

--- a/src/Controller/OrderController.php
+++ b/src/Controller/OrderController.php
@@ -26,7 +26,9 @@ use OxidSolutionCatalysts\AmazonPay\Core\Helper\PhpHelper;
 use OxidSolutionCatalysts\AmazonPay\Core\Logger;
 use OxidSolutionCatalysts\AmazonPay\Core\Payload;
 use OxidSolutionCatalysts\AmazonPay\Core\Provider\OxidServiceProvider;
+use OxidSolutionCatalysts\AmazonPay\Service\DeliveryAddressService;
 use stdClass;
+use OxidEsales\Eshop\Application\Model\Address as CoreAddress;
 
 /**
  * Class OrderController
@@ -153,6 +155,19 @@ class OrderController extends OrderController_parent
             $ret = parent::execute();
         }
         return $ret;
+    }
+
+    /**
+     * @return CoreAddress
+     */
+    public function getDelAddress()
+    {
+        $deliveryAddressService = new DeliveryAddressService();
+        if ($deliveryAddressService->isPaymentInSessionIsAmazonPay()) {
+            return $deliveryAddressService->getTempDeliveryAddressAddress();
+        }
+
+        return parent::getDelAddress();
     }
 
     protected function completeAmazonPayment()

--- a/src/Controller/PaymentController.php
+++ b/src/Controller/PaymentController.php
@@ -1,0 +1,31 @@
+<?php
+
+/**
+ * Copyright © OXID eSales AG. All rights reserved.
+ * See LICENSE file for license details.
+ */
+
+namespace OxidSolutionCatalysts\AmazonPay\Controller;
+
+use OxidSolutionCatalysts\AmazonPay\Service\DeliveryAddressService;
+
+/**
+ * @mixin \OxidEsales\Eshop\Application\Controller\PaymentController
+ */
+class PaymentController extends PaymentController_parent
+{
+    /**
+     * @return mixed
+     */
+    public function validatePayment()
+    {
+        $returnValue = parent::validatePayment();
+
+        $deliveryAddressService = new DeliveryAddressService();
+        if ($deliveryAddressService->isPaymentInSessionIsAmazonPay()) {
+            $deliveryAddressService->moveInSession();
+        }
+
+        return $returnValue;
+    }
+}

--- a/src/Core/Constants.php
+++ b/src/Core/Constants.php
@@ -33,6 +33,11 @@ class Constants
     const SESSION_CHECKOUT_ID = 'amzn-checkout-sess';
 
     /**
+     * @var string temp amazon delivery address id used to display delivery address in checkout
+     */
+    const SESSION_TEMP_DELIVERY_ADDRESS_ID = 'amazondeladrid';
+
+    /**
      * @var string Amazon checkout session param name deliveryaddr
      */
     const SESSION_DELIVERY_ADDR = 'amazondeladr';

--- a/src/Model/User.php
+++ b/src/Model/User.php
@@ -35,7 +35,6 @@ class User extends User_parent
         ) {
             parent::_assignAddress($aDelAddress);
         }
-        Registry::getSession()->setVariable('deladrid', null);
     }
 
     /**

--- a/src/Service/DeliveryAddressService.php
+++ b/src/Service/DeliveryAddressService.php
@@ -1,0 +1,54 @@
+<?php
+
+namespace OxidSolutionCatalysts\AmazonPay\Service;
+
+use OxidEsales\Eshop\Core\Registry;
+use OxidSolutionCatalysts\AmazonPay\Core\Constants;
+use OxidEsales\Eshop\Core\Session;
+use OxidEsales\Eshop\Application\Model\Address;
+
+class DeliveryAddressService
+{
+    /**
+     * avoid the delivery address is saved in core checkout from deladrid session variable and make it readable
+     * in amazondeladrid to be used in checkout template to display it
+     *
+     * @return void
+     */
+    public function moveInSession()
+    {
+        $session = $this->getSession();
+        $deliveryAddressId = $session->getVariable('deladrid');
+        $session->setVariable(Constants::SESSION_TEMP_DELIVERY_ADDRESS_ID, $deliveryAddressId);
+        $session->setVariable('deladrid', null);
+    }
+
+    /**
+     * @return bool
+     */
+    public function isPaymentInSessionIsAmazonPay()
+    {
+        $paymentId = Registry::getSession()->getVariable('paymentid');
+
+        return $paymentId === Constants::PAYMENT_ID;
+    }
+
+    /**
+     * @return Address
+     */
+    public function getTempDeliveryAddressAddress()
+    {
+        $deliveryAddress = oxNew(Address::class);
+        $deliveryAddress->load($this->getSession()->getVariable(Constants::SESSION_TEMP_DELIVERY_ADDRESS_ID));
+
+        return $deliveryAddress;
+    }
+
+    /**
+     * @return Session
+     */
+    protected function getSession()
+    {
+        return Registry::getSession();
+    }
+}

--- a/tests/PhpStan/phpstan-bootstrap.php
+++ b/tests/PhpStan/phpstan-bootstrap.php
@@ -86,3 +86,8 @@ class_alias(
     \OxidEsales\Eshop\Application\Model\Order::class,
     \OxidSolutionCatalysts\AmazonPay\Model\Order_parent::class
 );
+
+class_alias(
+    \OxidEsales\Eshop\Application\Controller\PaymentController::class,
+    \OxidSolutionCatalysts\AmazonPay\Controller\PaymentController_parent::class
+);


### PR DESCRIPTION
we now delete the session variable deladrid in step 4 where payment was chosen and copy it to another session variable amazondeladrid to be able to display the chosen delivery address in checkout and make sure the delivery address is not saved at the order without having amazon validating it