### PR TITLE
A few fixed issues in the module

### DIFF
--- a/CHANGELOG.md
+++ b/CHANGELOG.md
@@ -4,8 +4,11 @@ All notable changes to this project will be documented in this file.
 The format is based on [Keep a Changelog](http://keepachangelog.com/)
 and this project adheres to [Semantic Versioning](http://semver.org/).
 
-## [2.1.7] - 2024-??-??
+## [2.1.7] - 2025-??-??
 
+- Added `is_string` check for [PhpHelper::jsonToArray()](./src/Core/Helper/PhpHelper.php)
+- Fixed wrong namespace on Controller/Admin/OrderArticle 
+- Changed [Amazonclient::getCharge()](./src/Core/AmazonClient.php) to match the upstream library call
 - [0007715](https://bugs.oxid-esales.com/view.php?id=7715): Fix wrong HTML-Code-Output
 - [0007718](https://bugs.oxid-esales.com/view.php?id=7718): Fix compatibility-Issue with Core (Method-Return-Values must be compatible with CORE)
 - [0007728](https://bugs.oxid-esales.com/view.php?id=7728): Fix that Items are not added when paying with AmazonPay Express from Minibasket (Flyout)

--- a/src/Controller/Admin/OrderArticle.php
+++ b/src/Controller/Admin/OrderArticle.php
@@ -9,7 +9,7 @@ namespace OxidSolutionCatalysts\AmazonPay\Controller\Admin;
 
 use OxidEsales\Eshop\Core\Exception\DatabaseConnectionException;
 use OxidEsales\Eshop\Core\Exception\DatabaseErrorException;
-use OxidEsales\EshopCommunity\Core\Request;
+use OxidEsales\Eshop\Core\Registry;
 use OxidSolutionCatalysts\AmazonPay\Core\Config;
 use OxidSolutionCatalysts\AmazonPay\Core\Constants;
 use OxidSolutionCatalysts\AmazonPay\Core\Logger;
@@ -56,10 +56,9 @@ class OrderArticle extends OrderArticle_parent
         if (!$config->automatedRefundActivated()) {
             return;
         }
-        $request = new Request();
         // get article id
         /** @var string $sOrderArtId */
-        $sOrderArtId = $request->getRequestParameter('sArtID') ?: '';
+        $sOrderArtId = Registry::getRequest()->getRequestParameter('sArtID') ?: '';
         $sOrderId = $this->getEditObjectId() ?: '';
 
         $oOrderArticle = oxNew(\OxidEsales\Eshop\Application\Model\OrderArticle::class);

--- a/src/Core/AmazonClient.php
+++ b/src/Core/AmazonClient.php
@@ -94,7 +94,7 @@ class AmazonClient extends Client
      */
     public function getCharge($chargeId, $headers = []): array
     {
-        return $this->decodeResponse(parent::getChargePermission($chargeId, $headers));
+        return $this->decodeResponse(parent::getCharge($chargeId, $headers));
     }
 
     /**

--- a/src/Core/AmazonService.php
+++ b/src/Core/AmazonService.php
@@ -371,7 +371,7 @@ class AmazonService
         $response = PhpHelper::jsonToArray($result['response']);
 
         // in case of error, the resulting structure is different...
-        if (!isset($result['response'], $result['status']) || $result['status'] !== 200) {
+        if (!isset($result['response'], $result['status']) || ($result['status'] !== 200 && $result['status'] !== 202)) {
             $this->showErrorOnRedirect($logger, $result, (string)$basket->getOrderId());
         }
 

--- a/src/Core/AmazonService.php
+++ b/src/Core/AmazonService.php
@@ -609,13 +609,24 @@ class AmazonService
         if ($order->load($orderId)) {
             switch ($response['statusDetails']['state']) {
                 case "Declined":
-                    $order->updateAmazonPayOrderStatus('AMZ_AUTH_OR_CAPT_DECLINED', $result);
+                    $order->updateAmazonPayOrderStatus('AMZ_AUTH_OR_CAPT_DECLINED', [
+                        'result' => $result
+                    ]);
                     break;
                 case "Pending":
                     $order->updateAmazonPayOrderStatus('AMZ_PAYMENT_PENDING', $result);
                     break;
+                case 'Authorized':
+                    $order->updateAmazonPayOrderStatus('AMZ_2STEP_AUTH_OK', [
+                        'chargeAmount' => $response['chargeAmount']['amount'],
+                        'chargeId'     => $response['chargeId']
+                    ]);
+                    break;
                 case "Captured":
-                    $order->updateAmazonPayOrderStatus('AMZ_AUTH_AND_CAPT_OK', $result);
+                    $order->updateAmazonPayOrderStatus('AMZ_AUTH_AND_CAPT_OK', [
+                        'chargeAmount' => $response['chargeAmount']['amount'],
+                        'chargeId'     => $response['chargeId']
+                    ]);
                     break;
             }
         }

--- a/src/Core/Logger.php
+++ b/src/Core/Logger.php
@@ -82,7 +82,12 @@ class Logger extends AbstractLogger
         $context = [];
 
         if (!empty($result['response'])) {
-            $response = PhpHelper::jsonToArray($result['response']);
+            // ensure it is a string 
+            if (is_string($result['response'])){
+                $response = PhpHelper::jsonToArray($result['response']);
+            } else {
+                $response = $result['response'];
+            }
 
             if (!empty($response['statusDetails']['state'])) {
                 $context['message'] = $response['statusDetails']['state'];

--- a/src/Model/Order.php
+++ b/src/Model/Order.php
@@ -162,7 +162,11 @@ class Order extends Order_parent
             case "AMZ_AUTH_AND_CAPT_FAILED":
                 $remark = 'AmazonPay: ERROR';
                 if (!empty($data['result']['response'])) {
-                    $response = PhpHelper::jsonToArray($data['result']['response']);
+                    if (is_string($data['result']['response'])) {
+                        $response = PhpHelper::jsonToArray($data['result']['response']);
+                    } else {
+                        $response = $data['result']['response'];
+                    }
                     $remark .= ' (' . $response['reasonCode'] . ')';
                 }
                 $this->_setFieldData('oxtransstatus', 'NOT_FINISHED');
@@ -199,7 +203,11 @@ class Order extends Order_parent
             case "AMZ_AUTH_OR_CAPT_DECLINED":
                 $remark = 'AmazonPay: Auth or Capture Declined';
                 if (!empty($data['result']['response'])) {
-                    $response = PhpHelper::jsonToArray($data['result']['response']);
+                    if (is_string($data['result']['response'])){
+                        $response = PhpHelper::jsonToArray($data['result']['response']);
+                    } else {
+                        $response = $data['result']['response'];
+                    }
                     $remark .= ' (' . $response['reasonCode'] . ')';
                 }
                 $this->_setFieldData('oxtransstatus', 'NOT_FINISHED');


### PR DESCRIPTION
There are a few fixes in here:

- OrderArticle is now [properly namespaced](https://docs.oxid-esales.com/developer/en/6.3/system_architecture/unified_namespace/index.html#unified-namespace-classes)
  - Call Registry static from within the OrderArticle
 - AmazonClient getChargePermission should actually be getCharge() just like the upstream library
 - AmazonService is [allowed to return a 202 response](https://developer.amazon.com/docs/amazon-pay-api-v2/checkout-session.html#response-4)
 - Add authorized case to AmazonService and pass the logic a bit easier.
 - Wrap `is_string` where required