### PR TITLE
PSAPC-327: send additional user/address information to amazon

### DIFF
--- a/src/Core/Payload.php
+++ b/src/Core/Payload.php
@@ -172,8 +172,6 @@ class Payload
             unset($data['softDescriptor']);
         }
 
-
-
         if (!empty($this->checkoutChargeAmount)) {
             $data['chargeAmount'] = [];
             $data['chargeAmount']['amount'] = $this->checkoutChargeAmount;
@@ -407,12 +405,28 @@ class Payload
         $oxprivfon = $user->getFieldData('oxprivfon');
         /** @var string $oxmobfon */
         $oxmobfon = $user->getFieldData('oxmobfon');
+        /** @var string $oxcompany */
+        $oxcompany = $user->getFieldData('oxcompany');
+        /** @var string $oxaddinfo */
+        $oxaddinfo = $user->getFieldData('oxaddinfo');
 
-        $addressLine1 = sprintf(
-            '%s %s',
-            $oxstreet,
-            $oxstreetnr
-        );
+        if (!empty($oxcompany)) {
+            $addressLine1 = sprintf(
+                '%s',
+                $oxcompany,
+            );
+            $addressLine2 = sprintf(
+                '%s %s',
+                $oxstreet,
+                $oxstreetnr
+            );
+        } else {
+            $addressLine1 = sprintf(
+                '%s %s',
+                $oxstreet,
+                $oxstreetnr
+            );
+        }
 
         /** @var string $oxcountryid */
         $oxcountryid = $user->getFieldData('oxcountryid');
@@ -426,6 +440,8 @@ class Payload
         $this->addressDetails = [
             'name' => $oxfname . ' ' . $oxlname,
             'addressLine1' => $addressLine1,
+            'addressLine2' => $addressLine2,
+            'addressLine3' => $oxaddinfo,
             'postalCode' => $oxzip,
             'city' => $oxcity,
             'countryCode' => $sCountryCode
@@ -470,11 +486,29 @@ class Payload
         $oxprivfon = $address->getFieldData('oxprivfon');
         /** @var string $oxmobfon */
         $oxmobfon = $address->getFieldData('oxmobfon');
-        $addressLine1 = sprintf(
-            '%s %s',
-            $oxstreet,
-            $oxstreetnr
-        );
+        /** @var string $oxcompany */
+        $oxcompany = $address->getFieldData('oxcompany');
+        /** @var string $oxaddinfo */
+        $oxaddinfo = $address->getFieldData('oxaddinfo');
+
+        if (!empty($oxcompany)) {
+            $addressLine1 = sprintf(
+                '%s',
+                $oxcompany,
+            );
+            $addressLine2 = sprintf(
+                '%s %s',
+                $oxstreet,
+                $oxstreetnr
+            );
+        } else {
+            $addressLine1 = sprintf(
+                '%s %s',
+                $oxstreet,
+                $oxstreetnr
+            );
+        }
+
         /** @var string $oxcountryid */
         $oxcountryid = $address->getFieldData('oxcountryid');
         $oCountry = oxNew(Country::class);
@@ -485,6 +519,8 @@ class Payload
         $this->addressDetails = [
             'name' => $oxfname . ' ' . $oxlname,
             'addressLine1' => $addressLine1,
+            'addressLine2' => $addressLine2,
+            'addressLine3' => $oxaddinfo,
             'postalCode' => $oxzip,
             'city' => $oxcity,
             'countryCode' => $sCountryCode

--- a/src/Model/Order.php
+++ b/src/Model/Order.php
@@ -106,6 +106,14 @@ class Order extends Order_parent
             return parent::getDelAddressInfo();
         }
 
+        // prevent updating delivery address from amazon for normal amazonpay payments after returning from amazonpay
+        $session = Registry::getSession();
+        if (
+            $session->getVariable('paymentid') === Constants::PAYMENT_ID
+        ) {
+            return parent::getDelAddressInfo();
+        }
+
         $address = oxNew(Address::class);
         $address->assign($amazonDelAddress);
 


### PR DESCRIPTION
* oxcompany is now sent to amazonpay as addressLine1 oxstreet and oxstreetnr are sent in addressLine2
* if oxcompany is not set oxstreet and oxstreetnr are sent in addressLine1 (behaviour is unchanged)
* oxaddinfo is sent in addressLine3